### PR TITLE
CEL policies: Use of v1beta1 of Kubernetes ValidatingAdmissionPolicy

### DIFF
--- a/cel/C0001-container-image-tag/policy-C0001.yaml
+++ b/cel/C0001-container-image-tag/policy-C0001.yaml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ---
-apiVersion: admissionregistration.k8s.io/v1alpha1
+apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingAdmissionPolicy
 metadata:
   name: c0001.container.portefaix.xyz
@@ -30,7 +30,7 @@ spec:
   - key: "container-invalid-image-tag"
     valueExpression: "Container image must have a SemVer version and not lastest tag"
 ---
-apiVersion: admissionregistration.k8s.io/v1alpha1
+apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingAdmissionPolicyBinding
 metadata:
   name: c0001.container.portefaix.xyz

--- a/cel/C0002-container-liveness-probe/policy-C0002.yaml
+++ b/cel/C0002-container-liveness-probe/policy-C0002.yaml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ---
-apiVersion: admissionregistration.k8s.io/v1alpha1
+apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingAdmissionPolicy
 metadata:
   name: c0002.container.portefaix.xyz
@@ -33,7 +33,7 @@ spec:
   - key: "container-liveness-probe"
     valueExpression: "Liveness probe is required"
 ---
-apiVersion: admissionregistration.k8s.io/v1alpha1
+apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingAdmissionPolicyBinding
 metadata:
   name: c0002.container.portefaix.xyz

--- a/cel/C0003-container-readiness-probe/policy-C0003.yaml
+++ b/cel/C0003-container-readiness-probe/policy-C0003.yaml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ---
-apiVersion: admissionregistration.k8s.io/v1alpha1
+apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingAdmissionPolicy
 metadata:
   name: c0003.container.portefaix.xyz
@@ -33,7 +33,7 @@ spec:
   - key: "container-readiness-probe"
     valueExpression: "Readiness probe is required"
 ---
-apiVersion: admissionregistration.k8s.io/v1alpha1
+apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingAdmissionPolicyBinding
 metadata:
   name: c0003.container.portefaix.xyz

--- a/cel/C0008-container-resources/policy-C0008.yaml
+++ b/cel/C0008-container-resources/policy-C0008.yaml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ---
-apiVersion: admissionregistration.k8s.io/v1alpha1
+apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingAdmissionPolicy
 metadata:
   name: c0008.container.portefaix.xyz
@@ -56,7 +56,7 @@ spec:
   - key: "container-resources-requests-limits"
     valueExpression: "CPU and Memory resource requests and limits are required"
 ---
-apiVersion: admissionregistration.k8s.io/v1alpha1
+apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingAdmissionPolicyBinding
 metadata:
   name: c0008.container.portefaix.xyz

--- a/cel/M0001-metadata-labels/policy-M0001.yaml
+++ b/cel/M0001-metadata-labels/policy-M0001.yaml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ---
-apiVersion: admissionregistration.k8s.io/v1alpha1
+apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingAdmissionPolicy
 metadata:
   name: m0001.metadata.portefaix.xyz
@@ -40,7 +40,7 @@ spec:
   - key: "metadata-kubernetes-recommended-labels"
     valueExpression: "Kubernetes recommended labels is required"
 ---
-apiVersion: admissionregistration.k8s.io/v1alpha1
+apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingAdmissionPolicyBinding
 metadata:
   name: m0001.container.portefaix.xyz

--- a/cel/M0002-metadata-annotations/policy-M0002.yaml
+++ b/cel/M0002-metadata-annotations/policy-M0002.yaml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ---
-apiVersion: admissionregistration.k8s.io/v1alpha1
+apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingAdmissionPolicy
 metadata:
   name: m0002.metadata.portefaix.xyz
@@ -39,7 +39,7 @@ spec:
   - key: "metadata-a8r-io-recommended-annotations"
     valueExpression: "a8r.io annotations is required"
 ---
-apiVersion: admissionregistration.k8s.io/v1alpha1
+apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingAdmissionPolicyBinding
 metadata:
   name: m0002.container.portefaix.xyz

--- a/cel/M0003-metadata-portefaix-labels/policy-M0003.yaml
+++ b/cel/M0003-metadata-portefaix-labels/policy-M0003.yaml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ---
-apiVersion: admissionregistration.k8s.io/v1alpha1
+apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingAdmissionPolicy
 metadata:
   name: m0003.metadata.portefaix.xyz
@@ -34,7 +34,7 @@ spec:
   - key: "metadata-portefaix-recommended-labels"
     valueExpression: "Portefaix recommended labels is required"
 ---
-apiVersion: admissionregistration.k8s.io/v1alpha1
+apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingAdmissionPolicyBinding
 metadata:
   name: m0003.container.portefaix.xyz

--- a/cel/N0001-namespace-default/policy-N0001.yaml
+++ b/cel/N0001-namespace-default/policy-N0001.yaml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ---
-apiVersion: admissionregistration.k8s.io/v1alpha1
+apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingAdmissionPolicy
 metadata:
   name: n0001.namespace.portefaix.xyz
@@ -29,7 +29,7 @@ spec:
   - key: "default-namespace-not-allowed"
     valueExpression: "Resources in default namespace are not allowed"
 ---
-apiVersion: admissionregistration.k8s.io/v1alpha1
+apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingAdmissionPolicyBinding
 metadata:
   name: n0001.container.portefaix.xyz

--- a/cel/P0001-registry/policy-P0001.yaml
+++ b/cel/P0001-registry/policy-P0001.yaml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ---
-apiVersion: admissionregistration.k8s.io/v1alpha1
+apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingAdmissionPolicy
 metadata:
   labels:
@@ -38,7 +38,7 @@ spec:
   - key: "container-forbidden-registry"
     valueExpression: "Trust registry is required"
 ---
-apiVersion: admissionregistration.k8s.io/v1alpha1
+apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingAdmissionPolicyBinding
 metadata:
   name: c0004.container.portefaix.xyz


### PR DESCRIPTION
…s from alpha to beta API version.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated validation policy definitions to use Kubernetes API version v1beta1 across multiple policy categories, including container validation policies (liveness probes, readiness probes, resource management, image tags), metadata rules (labels, annotations, custom labels), namespace defaults, and registry policies. All existing validation behaviors, policy rules, and configurations remain fully functional and unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->